### PR TITLE
Value

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -103,3 +103,13 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "value_test",
+    srcs = ["value_test.cc"],
+    deps = [
+        ":value",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/base/BUILD
+++ b/base/BUILD
@@ -56,7 +56,6 @@ cc_library(
     ],
     srcs = [
         "value.cc",
-        "value_base.cc",
     ],
     deps = [
     	":type",

--- a/base/BUILD
+++ b/base/BUILD
@@ -51,9 +51,12 @@ cc_library(
     name = "value",
     hdrs = [
         "value.h",
+        "value_base.h",
+        "value_ptr.h",
     ],
     srcs = [
         "value.cc",
+        "value_base.cc",
     ],
     deps = [
     	":type",

--- a/base/BUILD
+++ b/base/BUILD
@@ -115,3 +115,13 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "value_ptr_test",
+    srcs = ["value_ptr_test.cc"],
+    deps = [
+        ":value",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/base/error_code.cc
+++ b/base/error_code.cc
@@ -7,6 +7,7 @@ const std::vector<ErrorCode>& GetErrorCodes() {
     kSuccess,
     kErrorUnknown,
     kErrorFailedPrecondition,
+    kErrorUnimplemented,
   };
   return kErrorCodes;
 }
@@ -19,6 +20,8 @@ std::string ErrorCodeToString(ErrorCode code) {
       return "ERROR[Unknown]";
     case kErrorFailedPrecondition:
       return "ERROR[Failed Precondition]";
+    case kErrorUnimplemented:
+      return "ERROR[Unimplemented]";
   }
   return "";
 }

--- a/base/error_code.h
+++ b/base/error_code.h
@@ -11,6 +11,7 @@ enum ErrorCode {
   kSuccess = 0,
   kErrorUnknown,
   kErrorFailedPrecondition,
+  kErrorUnimplemented,
 };
 
 const std::vector<ErrorCode>& GetErrorCodes();

--- a/base/error_code_test.cc
+++ b/base/error_code_test.cc
@@ -14,7 +14,7 @@ void ExpectErrorCodeName(const std::string &code_name,
 
 TEST(ErrorCodeTest, TestErrorCodes) {
   const auto &codes = GetErrorCodes();
-  EXPECT_EQ(3, codes.size());
+  EXPECT_EQ(4, codes.size());
   EXPECT_EQ(kSuccess, codes[0]);
   EXPECT_EQ(kErrorUnknown, codes[1]);
   EXPECT_EQ(kErrorFailedPrecondition, codes[2]);

--- a/base/error_code_test.cc
+++ b/base/error_code_test.cc
@@ -22,7 +22,7 @@ TEST(ErrorCodeTest, TestErrorCodes) {
 
 TEST(ErrorCodeTest, TestErrorCodeString) {
   static const std::vector<std::string> code_names = {
-      "", "Unknown", "Failed Precondition",
+    "", "Unknown", "Failed Precondition", "Unimplemented",
   };
 
   const auto &codes = GetErrorCodes();

--- a/base/error_code_test.cc
+++ b/base/error_code_test.cc
@@ -9,6 +9,7 @@ void ExpectErrorCodeName(const std::string &code_name,
                          const std::string &error) {
   std::ostringstream sout;
   sout << "ERROR[" << code_name << "]";
+  EXPECT_EQ(sout.str(), error);
 }
 
 TEST(ErrorCodeTest, TestErrorCodes) {

--- a/base/error_status.cc
+++ b/base/error_status.cc
@@ -21,4 +21,9 @@ ErrorStatus FailedPrecondtionError(const std::string& message) {
   return ErrorStatus(kErrorFailedPrecondition, message);
 }
 
+
+ErrorStatus UnimplementedError(const std::string& message) {
+  return ErrorStatus(kErrorUnimplemented, message);
+}
+
 }  // namespace llama

--- a/base/error_status.h
+++ b/base/error_status.h
@@ -40,6 +40,7 @@ class ErrorStatus {
 ErrorStatus Success();
 ErrorStatus UnknownError(const std::string& message);
 ErrorStatus FailedPrecondtionError(const std::string& message);
+ErrorStatus UnimplementedError(const std::string& message);
 
 }  // namespace llama
 

--- a/base/numeric_type.cc
+++ b/base/numeric_type.cc
@@ -52,6 +52,23 @@ std::uint32_t NumericType::Encode(ScalarType scalar, std::uint8_t bit_depth,
   return code;
 };
 
+size_t NumericType::GetSize(std::uint32_t code) {
+  std::uint8_t rank = GetRank(code);
+  std::size_t scalar_size = GetBitDepth(code) / 8;
+
+  if (rank == 0) {
+    return scalar_size;
+  } else if (rank == 1) {
+    std::uint8_t dim = GetRowDim(code);
+    return scalar_size * dim;
+  } else if (rank == 2) {
+    std::uint8_t row_dim = GetRowDim(code);
+    std::uint8_t col_dim = GetColDim(code);
+    return scalar_size * row_dim * col_dim;
+  }
+  return 0;
+}
+
 std::string NumericType::GetName(std::uint32_t code) {
   ScalarType scalar = GetScalarType(code);
   std::uint8_t rank = GetRank(code);

--- a/base/numeric_type.h
+++ b/base/numeric_type.h
@@ -42,6 +42,8 @@ class NumericType {
     return (code & kMaskColDim) >> kShiftColDim;
   }
 
+  static size_t GetSize(std::uint32_t code);
+
   static std::string GetName(std::uint32_t code);
 
  private:

--- a/base/type.cc
+++ b/base/type.cc
@@ -23,6 +23,30 @@ Type Type::Matrix(Type scalar, std::uint8_t row_dim, std::uint8_t col_dim) {
                                   {row_dim, col_dim}));
 }
 
+size_t Type::GetSize() const {
+  switch (GetCategory()) {
+    case kTypeUndefined:
+      return 0;
+    case kTypeNumeric:
+      return NumericType::GetSize(m_code);
+    case kTypeString:
+      break;
+    case kTypeEnum:
+      break;
+    case kTypeTuple:
+      break;
+    case kTypeArray:
+      break;
+    case kTypeDictionary:
+      break;
+    case kTypeBuffer:
+      break;
+    case kTypeCustom:
+      break;
+  }
+  return 0;
+}
+
 std::string Type::GetName() const {
   switch (GetCategory()) {
     case kTypeUndefined:
@@ -45,6 +69,58 @@ std::string Type::GetName() const {
       break;
   }
   return kUnknownTypeName;
+}
+
+Type::Initializer Type::GetInitializer() const {
+  switch (GetCategory()) {
+    case kTypeUndefined:
+    case kTypeNumeric:
+      return [](void* mem) { return Success(); };
+    case kTypeString:
+      break;
+    case kTypeEnum:
+      break;
+    case kTypeTuple:
+      break;
+    case kTypeArray:
+      break;
+    case kTypeDictionary:
+      break;
+    case kTypeBuffer:
+      break;
+    case kTypeCustom:
+      break;
+  }
+  return [this](void* mem) {
+    return UnimplementedError("GetInitializer is not implemented for type " +
+                              GetName());
+  };
+}
+
+Type::Finalizer Type::GetFinalizer() const {
+  switch (GetCategory()) {
+    case kTypeUndefined:
+    case kTypeNumeric:
+      return [](void* mem) { return Success(); };
+    case kTypeString:
+      break;
+    case kTypeEnum:
+      break;
+    case kTypeTuple:
+      break;
+    case kTypeArray:
+      break;
+    case kTypeDictionary:
+      break;
+    case kTypeBuffer:
+      break;
+    case kTypeCustom:
+      break;
+  }
+  return [this](void* mem) {
+    return UnimplementedError("GetFinalizer is not implemented for type " +
+                              GetName());
+  };
 }
 
 }  // namespace llama

--- a/base/type.cc
+++ b/base/type.cc
@@ -76,7 +76,10 @@ Type::Initializer Type::GetInitializer() const {
   switch (GetCategory()) {
     case kTypeUndefined:
     case kTypeNumeric:
-      return [](void* mem) { return Success(); };
+      return [this](void* mem) {
+        std::memset(mem, 0, this->GetSize());
+        return Success();
+      };
     case kTypeString:
       break;
     case kTypeEnum:
@@ -92,18 +95,16 @@ Type::Initializer Type::GetInitializer() const {
     case kTypeCustom:
       break;
   }
-  return [this](void* mem) {
-    return UnimplementedError("GetInitializer is not implemented for type " +
-                              GetName());
-  };
+  std::cerr <<"GetInitializer is not implemented for type " << GetName();
+  return Initializer();
 }
 
 Type::Copier Type::GetCopier() const {
   switch (GetCategory()) {
     case kTypeUndefined:
     case kTypeNumeric:
-      return [](const void* src, void* dst) {
-        std::memcpy(dst, src, GetSize());
+      return [this](const void* src, void* dst) {
+        std::memcpy(dst, src, this->GetSize());
         return Success();
       };
     case kTypeString:
@@ -121,17 +122,16 @@ Type::Copier Type::GetCopier() const {
     case kTypeCustom:
       break;
   }
-  return [this](void* mem) {
-    return UnimplementedError("GetInitializer is not implemented for type " +
-                              GetName());
-  };
+  std::cerr << "GetCopier is not implemented for type " << GetName();
+  return Copier();
 }
 
 Type::Mover Type::GetMover() const {
   switch (GetCategory()) {
     case kTypeUndefined:
     case kTypeNumeric:
-      return [](void* src, void* dst) {
+      return [this](const void* src, void* dst) {
+        std::memcpy(dst, src, this->GetSize());
         return Success();
       };
     case kTypeString:
@@ -149,10 +149,8 @@ Type::Mover Type::GetMover() const {
     case kTypeCustom:
       break;
   }
-  return [this](void* mem) {
-    return UnimplementedError("GetInitializer is not implemented for type " +
-                              GetName());
-  };
+  std::cerr << "GetMover is not implemented for type " << GetName();
+  return Mover();
 }
 
 Type::Finalizer Type::GetFinalizer() const {
@@ -175,10 +173,8 @@ Type::Finalizer Type::GetFinalizer() const {
     case kTypeCustom:
       break;
   }
-  return [this](void* mem) {
-    return UnimplementedError("GetFinalizer is not implemented for type " +
-                              GetName());
-  };
+  std::cerr << "GetFinalizer is not implemented for type " << GetName();
+  return Finalizer();
 }
 
 }  // namespace llama

--- a/base/type.cc
+++ b/base/type.cc
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstring>
 
 #include "base/type.h"
 
@@ -76,6 +77,63 @@ Type::Initializer Type::GetInitializer() const {
     case kTypeUndefined:
     case kTypeNumeric:
       return [](void* mem) { return Success(); };
+    case kTypeString:
+      break;
+    case kTypeEnum:
+      break;
+    case kTypeTuple:
+      break;
+    case kTypeArray:
+      break;
+    case kTypeDictionary:
+      break;
+    case kTypeBuffer:
+      break;
+    case kTypeCustom:
+      break;
+  }
+  return [this](void* mem) {
+    return UnimplementedError("GetInitializer is not implemented for type " +
+                              GetName());
+  };
+}
+
+Type::Copier Type::GetCopier() const {
+  switch (GetCategory()) {
+    case kTypeUndefined:
+    case kTypeNumeric:
+      return [](const void* src, void* dst) {
+        std::memcpy(dst, src, GetSize());
+        return Success();
+      };
+    case kTypeString:
+      break;
+    case kTypeEnum:
+      break;
+    case kTypeTuple:
+      break;
+    case kTypeArray:
+      break;
+    case kTypeDictionary:
+      break;
+    case kTypeBuffer:
+      break;
+    case kTypeCustom:
+      break;
+  }
+  return [this](void* mem) {
+    return UnimplementedError("GetInitializer is not implemented for type " +
+                              GetName());
+  };
+}
+
+Type::Mover Type::GetMover() const {
+  switch (GetCategory()) {
+    case kTypeUndefined:
+    case kTypeNumeric:
+      return [](void* src, void* dst) {
+        return Success();
+      };
     case kTypeString:
       break;
     case kTypeEnum:

--- a/base/type.h
+++ b/base/type.h
@@ -33,6 +33,8 @@ class Type {
     kTypeCustom = 8
   };
 
+  using Initializer = std::function<ErrorStatus (void*)>;
+  using Finalizer = std::function<ErrorStatus (void*)>;
   using ScalarType = NumericType::ScalarType;
 
   // Static contructors for numeric types.
@@ -60,13 +62,19 @@ class Type {
 
   // Accessors for all types.
   // =====================================================================
+  bool IsDefined() const { return GetCategory() != kTypeUndefined; }
+
   Category GetCategory() const {
     return static_cast<Category>(m_code & kMaskCategory);
   }
 
-  bool IsDefined() const { return GetCategory() != kTypeUndefined; }
+  size_t GetSize() const;
 
   std::string GetName() const;
+
+  Initializer GetInitializer() const;
+
+  Finalizer GetFinalizer() const;
 
   // Accessors for numeric types.
   // =====================================================================
@@ -86,6 +94,8 @@ class Type {
     return NumericType::GetBitDepth(m_code);
   }
 
+  bool operator== (const Type& other) const { return m_code == other.m_code; }
+
  private:
   static constexpr std::uint32_t kMaskCategory = 0xf;
 
@@ -93,6 +103,7 @@ class Type {
 
   std::uint32_t m_code;
 };
+
 
 template <typename T>
 Type TypeOf();

--- a/base/type.h
+++ b/base/type.h
@@ -34,6 +34,8 @@ class Type {
   };
 
   using Initializer = std::function<ErrorStatus (void*)>;
+  using Copier = std::function<ErrorStatus (const void*, void*)>;
+  using Mover = std::function<ErrorStatus (void*, void*)>;
   using Finalizer = std::function<ErrorStatus (void*)>;
   using ScalarType = NumericType::ScalarType;
 
@@ -73,6 +75,10 @@ class Type {
   std::string GetName() const;
 
   Initializer GetInitializer() const;
+
+  Copier GetCopier() const;
+
+  Mover GetMover() const;
 
   Finalizer GetFinalizer() const;
 

--- a/base/type.h
+++ b/base/type.h
@@ -62,6 +62,10 @@ class Type {
 
   static Type Matrix(Type scalar, std::uint8_t row_dim, std::uint8_t col_dim);
 
+  // Constructors.
+  // =====================================================================
+  Type() : m_code(0) {}
+
   // Accessors for all types.
   // =====================================================================
   bool IsDefined() const { return GetCategory() != kTypeUndefined; }

--- a/base/value.cc
+++ b/base/value.cc
@@ -1,7 +1,51 @@
 #include "base/value.h"
 
 namespace llama {
+namespace {
 
-Value::Value(Type t) : m_type(t) {}
+void DeleteValue(Value* value) {
+  ErrorStatus status = Value::Free(value);
+  Assert(!status.IsError(), "Failed to free value: " + status.GetMessage());
+}
+
+}
+
+ErrorStatus Value::Allocate(Type type, Ptr* value) {
+  size_t mem_size = sizeof(Type) + type.GetSize();
+  void* mem = malloc(mem_size);
+  Value* new_value = new (mem) Value(type);
+  ErrorStatus status = new_value->Initialize();
+  if (status.IsError()) {
+    free(mem);
+    return status;
+  }
+  *value = Ptr(new_value, DeleteValue);
+  return Success();
+}
+
+ErrorStatus Value::Free(Value* value) {
+  auto finalize = value->GetType().GetFinalizer();
+  RETURN_IF_ERROR(finalize(value->GetDataPtr()));
+  void* mem = reinterpret_cast<void*>(value);
+  free(mem);
+  return Success();
+}
+
+ErrorStatus Value::Initialize() {
+  auto initialize = m_type.GetInitializer();
+  return initialize(GetDataPtr());
+}
+
+void* Value::GetDataPtr() {
+  uint8_t* ptr = reinterpret_cast<uint8_t*>(this);
+  ptr += sizeof(Type);
+  return reinterpret_cast<void*>(ptr);
+}
+
+const void* Value::GetConstDataPtr() const {
+  const uint8_t* ptr = reinterpret_cast<const uint8_t*>(this);
+  ptr += sizeof(Type);
+  return reinterpret_cast<const void*>(ptr);
+}
 
 }  // namespace llama

--- a/base/value.cc
+++ b/base/value.cc
@@ -2,9 +2,9 @@
 
 namespace llama {
 
-constexpr size_t Value::kInPlaceValueSize = sizeof(std::string);
+constexpr size_t Value::kInPlaceValueSize;
 
-const void* Value::GetDataPtr() const final {
+const void* Value::GetDataPtr() const {
   if (IsInPlace()) {
     return reinterpret_cast<const void*>(m_data.in_place);
   } else {
@@ -12,7 +12,7 @@ const void* Value::GetDataPtr() const final {
   }
 }
 
-void* Value::GetMutableDataPtr() final {
+void* Value::GetMutableDataPtr() {
   if (IsInPlace()) {
     return reinterpret_cast<void*>(m_data.in_place);
   } else {

--- a/base/value.h
+++ b/base/value.h
@@ -1,26 +1,55 @@
 #ifndef LLAMA_VALUE_H
 #define LLAMA_VALUE_H
 
+#include <functional>
+#include <memory>
 #include <string>
 
+#include "base/error.h"
 #include "base/type.h"
 
 namespace llama {
 
 class Value {
  public:
-  Value(Type t);
+  using Deleter = std::function<void (Value*)>;
+  using Ptr = std::unique_ptr<Value, Deleter>;
+
+  static ErrorStatus Allocate(Type type, Ptr* value);
+  static ErrorStatus Free(Value* value);
+
+  template <class T>
+  static ErrorStatus Allocate(Ptr* value) {
+    return Allocate(TypeOf<T>(), value);
+  }
+
+  Type GetType() const { return m_type; }
+
+  template <class T>
+  const T& GetData() const {
+    Assert(TypeOf<T>() == m_type,
+           "Attempting to access value data as " + TypeName<T>() +
+               ", but value holds data of type " + m_type.GetName());
+    return *reinterpret_cast<const T*>(GetConstDataPtr());
+  }
+
+  template <class T>
+  T* GetMutableData() {
+    Assert(TypeOf<T>() == m_type,
+           "Attempting to access value data as " + TypeName<T>() +
+               ", but value holds data of type " + m_type.GetName());
+    return reinterpret_cast<T*>(GetDataPtr());
+  }
 
  private:
-  static constexpr int kInPlaceSize = sizeof(std::string);
+  Value(Type t) : m_type(t) {}
+
+  ErrorStatus Initialize();
+
+  void* GetDataPtr();
+  const void* GetConstDataPtr() const;
 
   Type m_type;
-  bool m_in_place_data;
-
-  union m_data {
-    uint8_t in_place[kInPlaceSize];
-    void* ptr;
-  };
 };
 
 }  // namespace llama

--- a/base/value.h
+++ b/base/value.h
@@ -9,9 +9,9 @@
 
 namespace llama {
 
-class Value : public MutablValueBase {
+class Value : public MutableValueBase {
  public:
-  static constexpr size_t kInPlaceValueSize;
+  static constexpr size_t kInPlaceValueSize = sizeof(std::string);
 
   // Construct an invalid value.
   Value() {}
@@ -19,24 +19,20 @@ class Value : public MutablValueBase {
   // Construct a value of type t.
   Value(Type t) : MutableValueBase(t) { Initialize(); }
 
-  template <class T>
-  Value() : Value(TypeOf<T>()) {}
-
   // Move constructor.
-  Value(Value&& value) : Value(value.GetType()) { Move(value); }
-
+  Value(Value&& value) : Value(value.GetType()) { Move(std::move(value)); }
 
   // Copy constructor.
   Value(const Value& value) : Value(value.GetType()) { Copy(value); }
 
-  ~Value() { Delete(); }
+  ~Value() final { Delete(); }
 
   const void* GetDataPtr() const final;
 
   void* GetMutableDataPtr() final;
 
   Value& operator= (Value&& value) {
-    Move(value);
+    Move(std::move(value));
     return *this;
   }
 

--- a/base/value.h
+++ b/base/value.h
@@ -17,7 +17,7 @@ class Value : public MutableValueBase {
   Value() {}
 
   // Construct a value of type t.
-  Value(Type t) : MutableValueBase(t) { Initialize(); }
+  explicit Value(Type t) : MutableValueBase(t) { Initialize(); }
 
   // Move constructor.
   Value(Value&& value) : Value(value.GetType()) { Move(std::move(value)); }

--- a/base/value_base.h
+++ b/base/value_base.h
@@ -1,0 +1,52 @@
+#ifndef LLAMA_VALUE_BASE_H
+#define LLAMA_VALUE_BASE_H
+
+#include <type_traits>
+
+#include "base/error.h"
+#include "base/type.h"
+
+namespace llama {
+
+class ValueBase {
+ public:
+  ValueBase() {}
+
+  ValueBase(Type type) : m_type(type) {}
+
+  Type GetType() const { return m_type; }
+
+  virtual const void* GetDataPtr() const = 0;
+
+  template <class T>
+  const T& Get() const {
+    Assert(TypeOf<T>() == m_type,
+           "Attempting to access value data as " + TypeName<T>() +
+           ", but value holds data of type " + m_type.GetName());
+    return *reinterpret_cast<const T*>(this->GetDataPtr());
+  }
+
+ private:
+  Type m_type;
+};
+
+class MutableValueBase : public ValueBase {
+ public:
+  MutableValueBase() {}
+
+  MutableValueBase(Type type) : ValueBase(type) {}
+
+  virtual void* GetMutableDataPtr() = 0;
+
+  template <class T>
+  typename T* GetMutable() {
+    Assert(TypeOf<T>() == m_type,
+           "Attempting to access value data as " + TypeName<T>() +
+               ", but value holds data of type " + m_type.GetName());
+    return reinterpret_cast<T*>(this->GetDataPtr());
+  }
+};
+
+}  // namespace llama
+
+#endif // LLAMA_VALUE_BASE_H

--- a/base/value_base.h
+++ b/base/value_base.h
@@ -14,6 +14,8 @@ class ValueBase {
 
   ValueBase(Type type) : m_type(type) {}
 
+  virtual ~ValueBase() {}
+
   Type GetType() const { return m_type; }
 
   virtual const void* GetDataPtr() const = 0;
@@ -26,7 +28,7 @@ class ValueBase {
     return *reinterpret_cast<const T*>(this->GetDataPtr());
   }
 
- private:
+ protected:
   Type m_type;
 };
 
@@ -39,11 +41,11 @@ class MutableValueBase : public ValueBase {
   virtual void* GetMutableDataPtr() = 0;
 
   template <class T>
-  typename T* GetMutable() {
+  T* GetMutable() {
     Assert(TypeOf<T>() == m_type,
            "Attempting to access value data as " + TypeName<T>() +
                ", but value holds data of type " + m_type.GetName());
-    return reinterpret_cast<T*>(this->GetDataPtr());
+    return reinterpret_cast<T*>(this->GetMutableDataPtr());
   }
 };
 

--- a/base/value_ptr.h
+++ b/base/value_ptr.h
@@ -1,0 +1,50 @@
+#ifndef LLAMA_VALUE_PTR_H
+#define LLAMA_VALUE_PTR_H
+
+#include "base/value_base.h"
+
+namespace llama {
+
+class ValuePtr : public ValueBase {
+ public:
+  ValuePtr() : m_ptr(nullptr) {}
+
+  ValuePtr(const Value* value)
+      : ValueBase(value->GetType()),
+        m_ptr(value->GeDataPtr()) {}
+
+  template <class T>
+  ValuePtr(const T* value)
+      : ValueBase(TypeOf<T>())
+        m_ptr(reinterpret_cast<const void*>(value)) {}
+
+  const void* GetDataPtr() const final { return m_ptr; }
+
+ private:
+  const void* m_ptr;
+};
+
+class MutableValuePtr : public MutableValueBase {
+ public:
+  MutableValuePtr() : m_ptr(nullptr) {}
+
+  MutableValuePtr(Value* value)
+      : MutableValueBase(value->GetType()),
+        m_ptr(value->GeDataPtr()) {}
+
+  template <class T>
+  MutableValuePtr(T* value)
+      : MutableValueBase(TypeOf<T>())
+        m_ptr(reinterpret_cast<void*>(value)) {}
+
+  const void* GetDataPtr() const final { return m_ptr; }
+
+  void* GetMutableDataPtr() final { return m_ptr; }
+
+ private:
+  void* m_ptr;
+};
+
+}  // namespace llama
+
+#endif  // LLAMA_VALUE_PTR_H

--- a/base/value_ptr.h
+++ b/base/value_ptr.h
@@ -5,11 +5,13 @@
 
 namespace llama {
 
+class MutableValuePtr;
+
 class ValuePtr : public ValueBase {
  public:
   ValuePtr() : m_ptr(nullptr) {}
 
-  ValuePtr(const Value* value)
+  ValuePtr(const ValueBase* value)
       : ValueBase(value->GetType()),
         m_ptr(value->GeDataPtr()) {}
 
@@ -17,6 +19,8 @@ class ValuePtr : public ValueBase {
   ValuePtr(const T* value)
       : ValueBase(TypeOf<T>())
         m_ptr(reinterpret_cast<const void*>(value)) {}
+
+  ValuePtr(const MutableValuePtr& mutable_ptr);
 
   const void* GetDataPtr() const final { return m_ptr; }
 
@@ -44,6 +48,9 @@ class MutableValuePtr : public MutableValueBase {
  private:
   void* m_ptr;
 };
+
+ValuePtr::ValuePtr(const MutableValuePtr& mutable_ptr)
+    : ValuePtr(&mutable_ptr) {}
 
 }  // namespace llama
 

--- a/base/value_ptr.h
+++ b/base/value_ptr.h
@@ -1,6 +1,9 @@
 #ifndef LLAMA_VALUE_PTR_H
 #define LLAMA_VALUE_PTR_H
 
+#include <type_traits>
+
+#include "base/value.h"
 #include "base/value_base.h"
 
 namespace llama {
@@ -11,14 +14,13 @@ class ValuePtr : public ValueBase {
  public:
   ValuePtr() : m_ptr(nullptr) {}
 
-  ValuePtr(const ValueBase* value)
-      : ValueBase(value->GetType()),
-        m_ptr(value->GeDataPtr()) {}
+  explicit ValuePtr(const ValueBase* value)
+      : ValueBase(value->GetType()), m_ptr(value->GetDataPtr()) {}
 
-  template <class T>
-  ValuePtr(const T* value)
-      : ValueBase(TypeOf<T>())
-        m_ptr(reinterpret_cast<const void*>(value)) {}
+  template <class T, typename = typename std::enable_if<
+                         !std::is_base_of<ValueBase, T>::value>::type>
+  explicit ValuePtr(const T* value)
+      : ValueBase(TypeOf<T>()), m_ptr(reinterpret_cast<const void*>(value)) {}
 
   ValuePtr(const MutableValuePtr& mutable_ptr);
 
@@ -32,14 +34,13 @@ class MutableValuePtr : public MutableValueBase {
  public:
   MutableValuePtr() : m_ptr(nullptr) {}
 
-  MutableValuePtr(Value* value)
-      : MutableValueBase(value->GetType()),
-        m_ptr(value->GeDataPtr()) {}
+  explicit MutableValuePtr(MutableValueBase* value)
+      : MutableValueBase(value->GetType()), m_ptr(value->GetMutableDataPtr()) {}
 
-  template <class T>
-  MutableValuePtr(T* value)
-      : MutableValueBase(TypeOf<T>())
-        m_ptr(reinterpret_cast<void*>(value)) {}
+  template <class T, typename = typename std::enable_if<
+                         !std::is_base_of<ValueBase, T>::value>::type>
+  explicit MutableValuePtr(T* value)
+      : MutableValueBase(TypeOf<T>()), m_ptr(reinterpret_cast<void*>(value)) {}
 
   const void* GetDataPtr() const final { return m_ptr; }
 

--- a/base/value_ptr_test.cc
+++ b/base/value_ptr_test.cc
@@ -1,0 +1,89 @@
+#include "base/value_ptr.h"
+#include "gtest/gtest.h"
+
+namespace llama {
+
+constexpr int kTestIntValue = 13331;
+constexpr float kTestFloatValue = 1.570796;
+
+TEST(ValuePtrTest, TestValuePtr) {
+  Value int_value(TypeOf<int>());
+  *int_value.GetMutable<int>() = kTestIntValue;
+  EXPECT_EQ(TypeOf<int>(), int_value.GetType());
+  EXPECT_EQ(kTestIntValue, int_value.Get<int>());
+  ValuePtr int_ptr(&int_value);
+  EXPECT_EQ(TypeOf<int>(), int_ptr.GetType());
+  EXPECT_EQ(kTestIntValue, int_ptr.Get<int>());
+  EXPECT_EQ(int_value.GetDataPtr(), int_ptr.GetDataPtr());
+
+  Value float_value(TypeOf<float>());
+  *float_value.GetMutable<float>() = kTestFloatValue;
+  EXPECT_EQ(TypeOf<float>(), float_value.GetType());
+  EXPECT_EQ(kTestFloatValue, float_value.Get<float>());
+  ValuePtr float_ptr(&float_value);
+  EXPECT_EQ(TypeOf<float>(), float_ptr.GetType());
+  EXPECT_EQ(kTestFloatValue, float_ptr.Get<float>());
+  EXPECT_EQ(float_value.GetDataPtr(), float_ptr.GetDataPtr());
+}
+
+TEST(ValuePtrTest, TestExternalValuePtr) {
+  int int_value = kTestIntValue;
+  ValuePtr int_ptr(&int_value);
+  EXPECT_EQ(TypeOf<int>(), int_ptr.GetType());
+  EXPECT_EQ(kTestIntValue, int_ptr.Get<int>());
+  EXPECT_EQ(&int_value, int_ptr.GetDataPtr());
+
+  float float_value = kTestFloatValue;
+  ValuePtr float_ptr(&float_value);
+  EXPECT_EQ(TypeOf<float>(), float_ptr.GetType());
+  EXPECT_FLOAT_EQ(kTestFloatValue, float_ptr.Get<float>());
+  EXPECT_EQ(&float_value, float_ptr.GetDataPtr());
+}
+
+TEST(ValuePtrTest, TestMutableValuePtr) {
+  Value int_value(TypeOf<int>());
+  *int_value.GetMutable<int>() = kTestIntValue;
+  EXPECT_EQ(TypeOf<int>(), int_value.GetType());
+  EXPECT_EQ(kTestIntValue, int_value.Get<int>());
+  MutableValuePtr int_ptr(&int_value);
+  EXPECT_EQ(TypeOf<int>(), int_ptr.GetType());
+  EXPECT_EQ(kTestIntValue, int_ptr.Get<int>());
+  EXPECT_EQ(int_value.GetDataPtr(), int_ptr.GetDataPtr());
+  *int_ptr.GetMutable<int>() = 33;
+  EXPECT_EQ(33, int_ptr.Get<int>());
+  EXPECT_EQ(33, int_value.Get<int>());
+
+  Value float_value(TypeOf<float>());
+  *float_value.GetMutable<float>() = kTestFloatValue;
+  EXPECT_EQ(TypeOf<float>(), float_value.GetType());
+  EXPECT_FLOAT_EQ(kTestFloatValue, float_value.Get<float>());
+  MutableValuePtr float_ptr(&float_value);
+  EXPECT_EQ(TypeOf<float>(), float_ptr.GetType());
+  EXPECT_FLOAT_EQ(kTestFloatValue, float_ptr.Get<float>());
+  EXPECT_EQ(float_value.GetDataPtr(), float_ptr.GetDataPtr());
+  *float_ptr.GetMutable<float>() = 2.71828;
+  EXPECT_FLOAT_EQ(2.71828, float_ptr.Get<float>());
+  EXPECT_FLOAT_EQ(2.71828, float_value.Get<float>());
+}
+
+TEST(ValuePtrTest, TestExternalMutableValuePtr) {
+  int int_value = kTestIntValue;
+  MutableValuePtr int_ptr(&int_value);
+  EXPECT_EQ(TypeOf<int>(), int_ptr.GetType());
+  EXPECT_EQ(kTestIntValue, int_ptr.Get<int>());
+  EXPECT_EQ(&int_value, int_ptr.GetDataPtr());
+  *int_ptr.GetMutable<int>() = 33;
+  EXPECT_EQ(33, int_ptr.Get<int>());
+  EXPECT_EQ(33, int_value);
+
+  float float_value = kTestFloatValue;
+  MutableValuePtr float_ptr(&float_value);
+  EXPECT_EQ(TypeOf<float>(), float_ptr.GetType());
+  EXPECT_FLOAT_EQ(kTestFloatValue, float_ptr.Get<float>());
+  EXPECT_EQ(&float_value, float_ptr.GetDataPtr());
+  *float_ptr.GetMutable<float>() = 2.71828;
+  EXPECT_FLOAT_EQ(2.71828, float_ptr.Get<float>());
+  EXPECT_FLOAT_EQ(2.71828, float_value);
+}
+
+}  // namespace llama

--- a/base/value_test.cc
+++ b/base/value_test.cc
@@ -3,28 +3,20 @@
 
 namespace llama {
 
-TEST(ValueTest, TestAllocateFreeValue) {
-  Value::Ptr value;
-  ErrorStatus status = Value::Allocate<int>(&value);
-  ASSERT_FALSE(status.IsError());
-  status = Value::Free(value.get());
-  ASSERT_FALSE(status.IsError());
-  value.release();
+TEST(ValueTest, TestConstructAndDelete) {
+  Value* value = new Value(TypeOf<int>());
+  EXPECT_EQ(TypeOf<int>(), value->GetType());
+  delete value;
 }
 
 TEST(ValueTest, TestGetData) {
-  ErrorStatus status;
-  Value::Ptr int_value;
-  status = Value::Allocate<int>(&int_value);
-  ASSERT_FALSE(status.IsError());
-  *int_value->GetMutableData<int>()  = 13331;
-  EXPECT_EQ(13331, int_value->GetData<int>());
+  Value int_value(TypeOf<int>());
+  *int_value.GetMutable<int>() = 13331;
+  EXPECT_EQ(13331, int_value.Get<int>());
 
-  Value::Ptr float_value;
-  status = Value::Allocate<float>(&float_value);
-  ASSERT_FALSE(status.IsError());
-  *float_value->GetMutableData<float>()  = 1.570796;
-  EXPECT_FLOAT_EQ(1.570796, float_value->GetData<float>());
+  Value float_value(TypeOf<float>());
+  *float_value.GetMutable<float>() = 1.570796;
+  EXPECT_FLOAT_EQ(1.570796, float_value.Get<float>());
 }
 
 }  // namespace llama

--- a/base/value_test.cc
+++ b/base/value_test.cc
@@ -3,6 +3,9 @@
 
 namespace llama {
 
+constexpr int kTestIntValue = 13331;
+constexpr float kTestFloatValue = 1.570796;
+
 TEST(ValueTest, TestConstructAndDelete) {
   Value* value = new Value(TypeOf<int>());
   EXPECT_EQ(TypeOf<int>(), value->GetType());
@@ -11,12 +14,44 @@ TEST(ValueTest, TestConstructAndDelete) {
 
 TEST(ValueTest, TestGetData) {
   Value int_value(TypeOf<int>());
-  *int_value.GetMutable<int>() = 13331;
-  EXPECT_EQ(13331, int_value.Get<int>());
+  *int_value.GetMutable<int>() = kTestIntValue;
+  EXPECT_EQ(kTestIntValue, int_value.Get<int>());
 
   Value float_value(TypeOf<float>());
-  *float_value.GetMutable<float>() = 1.570796;
-  EXPECT_FLOAT_EQ(1.570796, float_value.Get<float>());
+  *float_value.GetMutable<float>() = kTestFloatValue;
+  EXPECT_FLOAT_EQ(kTestFloatValue, float_value.Get<float>());
+}
+
+TEST(ValueTest, TestCopy) {
+  Value int_value(TypeOf<int>());
+  *int_value.GetMutable<int>() = kTestIntValue;
+  EXPECT_EQ(kTestIntValue, int_value.Get<int>());
+  Value int_copy = int_value;
+  EXPECT_EQ(TypeOf<int>(), int_copy.GetType());
+  EXPECT_EQ(kTestIntValue, int_copy.Get<int>());
+
+  Value float_value(TypeOf<float>());
+  *float_value.GetMutable<float>() = kTestFloatValue;
+  EXPECT_FLOAT_EQ(kTestFloatValue, float_value.Get<float>());
+  Value float_copy = float_value;
+  EXPECT_EQ(TypeOf<float>(), float_copy.GetType());
+  EXPECT_EQ(kTestFloatValue, float_copy.Get<float>());
+}
+
+TEST(ValueTest, TestMove) {
+  Value int_value(TypeOf<int>());
+  *int_value.GetMutable<int>() = kTestIntValue;
+  EXPECT_EQ(kTestIntValue, int_value.Get<int>());
+  Value int_move = std::move(int_value);
+  EXPECT_EQ(TypeOf<int>(), int_move.GetType());
+  EXPECT_EQ(kTestIntValue, int_move.Get<int>());
+
+  Value float_value(TypeOf<float>());
+  *float_value.GetMutable<float>() = kTestFloatValue;
+  EXPECT_FLOAT_EQ(kTestFloatValue, float_value.Get<float>());
+  Value float_move = std::move(float_value);
+  EXPECT_EQ(TypeOf<float>(), float_move.GetType());
+  EXPECT_EQ(kTestFloatValue, float_move.Get<float>());
 }
 
 }  // namespace llama

--- a/base/value_test.cc
+++ b/base/value_test.cc
@@ -1,0 +1,30 @@
+#include "base/value.h"
+#include "gtest/gtest.h"
+
+namespace llama {
+
+TEST(ValueTest, TestAllocateFreeValue) {
+  Value::Ptr value;
+  ErrorStatus status = Value::Allocate<int>(&value);
+  ASSERT_FALSE(status.IsError());
+  status = Value::Free(value.get());
+  ASSERT_FALSE(status.IsError());
+  value.release();
+}
+
+TEST(ValueTest, TestGetData) {
+  ErrorStatus status;
+  Value::Ptr int_value;
+  status = Value::Allocate<int>(&int_value);
+  ASSERT_FALSE(status.IsError());
+  *int_value->GetMutableData<int>()  = 13331;
+  EXPECT_EQ(13331, int_value->GetData<int>());
+
+  Value::Ptr float_value;
+  status = Value::Allocate<float>(&float_value);
+  ASSERT_FALSE(status.IsError());
+  *float_value->GetMutableData<float>()  = 1.570796;
+  EXPECT_FLOAT_EQ(1.570796, float_value->GetData<float>());
+}
+
+}  // namespace llama


### PR DESCRIPTION
Reorganizes the Value class into base classes ValueBase and MutableValueBase. Adds ValuePtr and MutableValuePtr as means of referencing values in memory that are not owned by the object. Implements copy and move constructors and operators for value. Adds test for all these.